### PR TITLE
Fix test failures for test_validation

### DIFF
--- a/simphony_metadata/scripts/tests/test_validation.py
+++ b/simphony_metadata/scripts/tests/test_validation.py
@@ -5,13 +5,14 @@ from mock import patch
 
 from .cuba import CUBA
 from .keywords import KEYWORDS
-from .meta_class.validation import (decode_shape,
-                                    check_shape,
-                                    validate_cuba_keyword)
+
 with patch('simphony.core.cuba.CUBA', CUBA),\
-     patch('simphony.core.data_container.CUBA', CUBA),\
-     patch('simphony.core.keywords.KEYWORDS', KEYWORDS):
-        from .meta_class import api
+         patch('simphony.core.data_container.CUBA', CUBA),\
+         patch('simphony.core.keywords.KEYWORDS', KEYWORDS):
+    from .meta_class import api
+    from .meta_class.validation import (decode_shape,
+                                        check_shape,
+                                        validate_cuba_keyword)
 
 
 @patch('simphony.core.data_container.CUBA', CUBA)


### PR DESCRIPTION
Fix #30 

`meta_class.validation` also imports CUBA from simphony-common, which needs to be patched.  Otherwise tests run after `test_validation` would have unpatched CUBA modules
