### PR TITLE
Problem: meta classes replace data instead of updating

### DIFF
--- a/simphony_metadata/scripts/generate.py
+++ b/simphony_metadata/scripts/generate.py
@@ -646,7 +646,7 @@ class CodeGenerator(object):
         self.imports.append(IMPORT_PATHS['create_data_container'])
 
         self.init_body.append('''if data:
-            self.data = data''')
+            self.data.update(data)''')
 
         self.methods.append('''
     @property


### PR DESCRIPTION
When the `data` named parameter is passed to the constructor of any generated class, it will replace the internal `data`, no matter whether it provides all the necessary keywords such as `CUBA.NAME`. 

Solution: update internal `data` instead of replacing it.
