### PR TITLE
Problem: mandatory keyword restriction is forced

### DIFF
--- a/simphony_metadata/scripts/generate.py
+++ b/simphony_metadata/scripts/generate.py
@@ -364,20 +364,7 @@ class CodeGenerator(object):
 
     def populate_module_variables(self):
         ''' Populate module-level variables '''
-
-        supported_parameters = self.supported_parameters
-        if not supported_parameters:
-            supported_parameters = 'CUBA'
-
-        self.module_variables.append(
-            transform_cuba_string(
-                '_RestrictedDataContainer = '
-                'create_data_container(\n'
-                '{indent}{supported_parameters},\n'
-                '{indent}class_name="_RestrictedDataContainer")'.format(
-                    supported_parameters=supported_parameters,
-                    indent=' '*4))
-        )
+        pass
 
     def populate_class_variables(self):
         ''' Populate class variables
@@ -643,7 +630,7 @@ class CodeGenerator(object):
                        "Given: {}")
             warnings.warn(message.format(contents))
 
-        self.imports.append(IMPORT_PATHS['create_data_container'])
+        self.imports.append(IMPORT_PATHS['DataContainer'])
 
         self.init_body.append('''if data:
             self.data = data''')
@@ -654,23 +641,23 @@ class CodeGenerator(object):
         try:
             data_container = self._data
         except AttributeError:
-            self._data = _RestrictedDataContainer()
+            self._data = DataContainer()
             return self._data
         else:
             # One more check in case the
             # property setter is by-passed
-            if not isinstance(data_container, _RestrictedDataContainer):
-                raise TypeError("data is not a RestrictedDataContainer. "
+            if not isinstance(data_container, DataContainer):
+                raise TypeError("data is not a DataContainer. "
                                 "data.setter is by-passed.")
             return data_container''')
 
         self.methods.append('''
     @data.setter
     def data(self, new_data):
-        if isinstance(new_data, _RestrictedDataContainer):
+        if isinstance(new_data, DataContainer):
             self._data = new_data
         else:
-            self._data = _RestrictedDataContainer(new_data)''')
+            self._data = DataContainer(new_data)''')
 
     def collect_parents_to_mro(self, generators):
         ''' Recursively collect all the inherited into CodeGenerator.mro
@@ -762,9 +749,10 @@ class CodeGenerator(object):
         ----------
         file_out : file object
         '''
-        print("", file=file_out)
-        print(*self.module_variables,
-              sep="\n", file=file_out)
+        if self.module_variables and len(self.module_variables) > 0:
+            print("", file=file_out)
+            print(*self.module_variables,
+                  sep="\n", file=file_out)
 
     def generate_class_header(self, file_out):
         ''' Print class definition to the file output

--- a/simphony_metadata/scripts/tests/test_meta_class.py
+++ b/simphony_metadata/scripts/tests/test_meta_class.py
@@ -7,6 +7,7 @@ from mock import patch
 import numpy
 import uuid
 
+from simphony.core.data_container import create_data_container
 from .cuba import CUBA
 from .keywords import KEYWORDS
 
@@ -320,12 +321,6 @@ class TestMetaClass(unittest.TestCase):
         actual = gravity_model.acceleration
         numpy.testing.assert_allclose(actual, expected)
 
-    def test_assign_data_with_unsupported_parameters(self):
-        ''' Test for assigning unsupported CUBA keys to data '''
-
-        with self.assertRaises(ValueError):
-            meta_class.Material(data={CUBA.SIZE: 1})
-
     def test_Basis(self):
         basis = meta_class.Basis()
         arr = basis.vector == numpy.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]])
@@ -346,3 +341,14 @@ class TestMetaClass(unittest.TestCase):
         box2 = meta_class.Box()
         box1.vector[0][0] = 1.
         self.assertNotEqual(box1.vector[0][0], box2.vector[0][0])
+
+    def test_assign_data_with_unsupported_parameters(self):
+        ''' Test for assigning unsupported CUBA keys to data '''
+        RDC = create_data_container(meta_class.Material.supported_parameters())
+        rdc = RDC()
+        rdc[CUBA.NAME] = 'test_material'
+        rdc[CUBA.DESCRIPTION] = 'Just another material'
+        mat = meta_class.Material(data=rdc)
+
+        with self.assertRaises(ValueError):
+            mat.data[CUBA.SIZE] = 1


### PR DESCRIPTION
This PR disables mandatory keyword restriction on `data` property of `CUDS` classes. In order to have restriction, one must do it manually:

```
RestrictedDataContainer = create_data_container(Material.supported_parameters())
rdc = RestrictedDataContainer()
rdc[CUBA.NAME] = 'myname'
m1 = Material(data=rdc)
m2 = Material()
m1.data[CUBA.MASS] = 1.0 # Not allowed
m2.data[CUBA.MASS] = 1.0 #Allowed by default
```

Solution: disable it.
