### PR TITLE
Problem: tests fail because of patching problem.

### DIFF
--- a/simphony_metadata/scripts/tests/test_meta_class.py
+++ b/simphony_metadata/scripts/tests/test_meta_class.py
@@ -7,20 +7,24 @@ from mock import patch
 import numpy
 import uuid
 
-from simphony.core.data_container import create_data_container
+
 from .cuba import CUBA
 from .keywords import KEYWORDS
 
 # We need to patch the CUBA values before importing the meta class
 with patch('simphony.core.cuba.CUBA', CUBA),\
-         patch('simphony.core.data_container.CUBA', CUBA),\
-         patch('simphony.core.keywords.KEYWORDS', KEYWORDS):
+     patch('simphony.core.data_container.CUBA', CUBA),\
+     patch('simphony.core.keywords.KEYWORDS', KEYWORDS),\
+     patch('simphony.core.data_container.DataContainer.restricted_keys', frozenset(CUBA)),\
+     patch('simphony.core.data_container.DataContainer._restricted_mapping', CUBA.__members__):
     from .meta_class import api as meta_class
+    from simphony.core.data_container import create_data_container
 
-
+@patch('simphony.core.data_container.DataContainer.restricted_keys', frozenset(CUBA))
+@patch('simphony.core.data_container.DataContainer._restricted_mapping', CUBA.__members__)
 @patch('simphony.core.data_container.CUBA', CUBA)
-@patch('simphony.core.cuba.CUBA', CUBA)
 @patch('simphony.core.keywords.KEYWORDS', KEYWORDS)
+@patch('simphony.core.cuba.CUBA', CUBA)
 class TestMetaClass(unittest.TestCase):
 
     @classmethod

--- a/simphony_metadata/scripts/tests/test_meta_class.py
+++ b/simphony_metadata/scripts/tests/test_meta_class.py
@@ -15,13 +15,18 @@ from .keywords import KEYWORDS
 with patch('simphony.core.cuba.CUBA', CUBA),\
      patch('simphony.core.data_container.CUBA', CUBA),\
      patch('simphony.core.keywords.KEYWORDS', KEYWORDS),\
-     patch('simphony.core.data_container.DataContainer.restricted_keys', frozenset(CUBA)),\
-     patch('simphony.core.data_container.DataContainer._restricted_mapping', CUBA.__members__):
+     patch('simphony.core.data_container.DataContainer.restricted_keys',
+           frozenset(CUBA)),\
+     patch('simphony.core.data_container.DataContainer._restricted_mapping',
+           CUBA.__members__):
     from .meta_class import api as meta_class
     from simphony.core.data_container import create_data_container
 
-@patch('simphony.core.data_container.DataContainer.restricted_keys', frozenset(CUBA))
-@patch('simphony.core.data_container.DataContainer._restricted_mapping', CUBA.__members__)
+
+@patch('simphony.core.data_container.DataContainer.restricted_keys',
+       frozenset(CUBA))
+@patch('simphony.core.data_container.DataContainer._restricted_mapping',
+       CUBA.__members__)
 @patch('simphony.core.data_container.CUBA', CUBA)
 @patch('simphony.core.keywords.KEYWORDS', KEYWORDS)
 @patch('simphony.core.cuba.CUBA', CUBA)

--- a/simphony_metadata/scripts/tests/test_validation.py
+++ b/simphony_metadata/scripts/tests/test_validation.py
@@ -9,16 +9,20 @@ from .keywords import KEYWORDS
 with patch('simphony.core.cuba.CUBA', CUBA),\
      patch('simphony.core.data_container.CUBA', CUBA),\
      patch('simphony.core.keywords.KEYWORDS', KEYWORDS),\
-     patch('simphony.core.data_container.DataContainer.restricted_keys', frozenset(CUBA)),\
-     patch('simphony.core.data_container.DataContainer._restricted_mapping', CUBA.__members__):
+     patch('simphony.core.data_container.DataContainer.restricted_keys',
+           frozenset(CUBA)),\
+     patch('simphony.core.data_container.DataContainer._restricted_mapping',
+           CUBA.__members__):
     from .meta_class import api
     from .meta_class.validation import (decode_shape,
                                         check_shape,
                                         validate_cuba_keyword)
 
 
-@patch('simphony.core.data_container.DataContainer.restricted_keys', frozenset(CUBA))
-@patch('simphony.core.data_container.DataContainer._restricted_mapping', CUBA.__members__)
+@patch('simphony.core.data_container.DataContainer.restricted_keys',
+       frozenset(CUBA))
+@patch('simphony.core.data_container.DataContainer._restricted_mapping',
+       CUBA.__members__)
 @patch('simphony.core.data_container.CUBA', CUBA)
 @patch('simphony.core.keywords.KEYWORDS', KEYWORDS)
 @patch('simphony.core.cuba.CUBA', CUBA)

--- a/simphony_metadata/scripts/tests/test_validation.py
+++ b/simphony_metadata/scripts/tests/test_validation.py
@@ -6,18 +6,22 @@ from mock import patch
 from .cuba import CUBA
 from .keywords import KEYWORDS
 
-with patch('simphony.core.keywords.KEYWORDS', KEYWORDS,
-           patch('simphony.core.cuba.CUBA', CUBA),
-           patch('simphony.core.data_container.CUBA', CUBA)):
+with patch('simphony.core.cuba.CUBA', CUBA),\
+     patch('simphony.core.data_container.CUBA', CUBA),\
+     patch('simphony.core.keywords.KEYWORDS', KEYWORDS),\
+     patch('simphony.core.data_container.DataContainer.restricted_keys', frozenset(CUBA)),\
+     patch('simphony.core.data_container.DataContainer._restricted_mapping', CUBA.__members__):
     from .meta_class import api
     from .meta_class.validation import (decode_shape,
                                         check_shape,
                                         validate_cuba_keyword)
 
 
+@patch('simphony.core.data_container.DataContainer.restricted_keys', frozenset(CUBA))
+@patch('simphony.core.data_container.DataContainer._restricted_mapping', CUBA.__members__)
 @patch('simphony.core.data_container.CUBA', CUBA)
-@patch('simphony.core.cuba.CUBA', CUBA)
 @patch('simphony.core.keywords.KEYWORDS', KEYWORDS)
+@patch('simphony.core.cuba.CUBA', CUBA)
 class TestValidation(unittest.TestCase):
 
     def test_decode_shape(self):


### PR DESCRIPTION
Solution: patch the the missing spots.

Upon import the class definition loads once and therefore the class variables remain unchanged even after patching. This PR adds them to the patch list.
