### PR TITLE
Problem: BRAVAIS_LATTICE entry has ill-formatted PRIMITIVE_CELL default value

### DIFF
--- a/yaml_files/simphony_metadata.yml
+++ b/yaml_files/simphony_metadata.yml
@@ -609,7 +609,6 @@ CUDS_KEYS:
       default: [1, 1, 1]
     ORIGIN:
     CUBA.PRIMITIVE_CELL:
-      default: [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]
     CUBA.LATTICE_PARAMETER:
       shape: (3)
       default: [1.0, 1.0, 1.0]


### PR DESCRIPTION
Solution: remove the default value 

`BRAVAIS_LATTICE` CUBA entry has an array as its default value for `PRIMITIVE_CELL` attribute, however, we have so far no way to assign a default value for non-primitive CUBAs. Therefore this causes problems and I had to remove it and rely on the default value defined in `PRIMITIVE_CELL` itself.
