### PR TITLE
Fixed incorrect name for physics_equations

### DIFF
--- a/docs/format.md
+++ b/docs/format.md
@@ -285,8 +285,8 @@ the parser to validate the final format.
 
     - ``CUDS variables``: entries must refer to data types as defined in the cuba.yml file.
  
-    - ``CUDS physics_equation``:
-        - The strings contained in this list MUST refer to a child of PHYSICS_EQUATION.
+    - ``CUDS physics_equations``:
+        - The entries contained in this list MUST refer to a child of PHYSICS_EQUATION.
 
         - The entry is only valid for ``COMPUTATIONAL_METHOD`` and its children.
           An error MUST be raised if found under any other keyword.

--- a/yaml_files/simphony_metadata.yml
+++ b/yaml_files/simphony_metadata.yml
@@ -437,32 +437,32 @@ CUDS_KEYS:
   COMPUTATIONAL_METHOD:
     parent: CUBA.SOLVER_PARAMETER
     definition: A computational method according to the RoMM
-    physics_equation: []
+    physics_equations: []
 
   DEM:
     parent: CUBA.COMPUTATIONAL_METHOD
     definition: Discrete element method
-    physics_equation: [CUBA.GRANULAR_DYNAMICS]
+    physics_equations: [CUBA.GRANULAR_DYNAMICS]
 
   FVM:
     parent: CUBA.COMPUTATIONAL_METHOD
     definition: Finite volume method
-    physics_equation: [CUBA.CFD]
+    physics_equations: [CUBA.CFD]
 
   FEM:
     parent: CUBA.COMPUTATIONAL_METHOD
     definition: Finite element method
-    physics_equation: [CUBA.CFD]
+    physics_equations: [CUBA.CFD]
 
   SPH:
     parent: CUBA.COMPUTATIONAL_METHOD
     definition: Smooth particle hydrodynamics
-    physics_equation: [CUBA.CFD]
+    physics_equations: [CUBA.CFD]
 
   VERLET:
     parent: CUBA.COMPUTATIONAL_METHOD
     definition: Newtonian dynamics integration using verlet algorithm
-    physics_equation: [CUBA.MOLECULAR_DYNAMICS]
+    physics_equations: [CUBA.MOLECULAR_DYNAMICS]
 
   INTEGRATION_TIME:
     parent: CUBA.SOLVER_PARAMETER


### PR DESCRIPTION
Fixed incorrect name for physics_equations, both in the specs and in the file.
