### PR TITLE
Made length mandatory in case of strings

### DIFF
--- a/docs/format.md
+++ b/docs/format.md
@@ -120,9 +120,8 @@ It MAY also contain:
         If not present, the default is the list ``[1]``
 
     ``length``: integer
-        This key MAY be present if the type is ``string``. It MUST NOT be present otherwise.
-        If present, it constraints the length of the string to the specified amount.
-        If not present, the string can have arbitrary length.
+        This key MUST be present if the type is ``string``. It MUST NOT be present otherwise.
+        It constraints the length of the string to the specified amount.
 
 simphony_metadata.yml
 ---------------------

--- a/yaml_files/cuba.yml
+++ b/yaml_files/cuba.yml
@@ -502,10 +502,12 @@ CUBA_KEYS:
   THERMODYNAMIC_ENSEMBLE:
     definition: Thermodynamic ensemble
     type: string
+    length: 4096
 
   VARIABLE:
     definition: a list of physics/chemistry variables in a PE or MR
     type: string
+    length: 4096
 
   NONE:
     definition: a general none value


### PR DESCRIPTION
It appears that our current underlying pytables infrastructure cannot handle
arbitrary length strings, so for now we require fixed length strings.