### PR TITLE
Adding a multiphase material metadata

### DIFF
--- a/yaml_files/simphony_metadata.yml
+++ b/yaml_files/simphony_metadata.yml
@@ -453,6 +453,15 @@ CUDS_KEYS:
       shape: [2]
 
   ######################################################
+  # Materials
+  ######################################################
+  MULTIPHASE_MATERIAL:
+    definition: a multiphase material system, specifies the materials composing the mixture, or suspension, or multicrystal, etc.
+    parent: CUBA.MATERIAL
+    CUBA.MATERIAL:
+      shape: (:)
+
+  ######################################################
   # Conditions on Boundaries
   ######################################################
   DIRICHLET:


### PR DESCRIPTION
allows a user to manage a composition more easilly in cases where it is needed. @khiltunen please review. 