### PR TITLE
Added cohesive group

### DIFF
--- a/yaml_files/cuba.yml
+++ b/yaml_files/cuba.yml
@@ -536,3 +536,7 @@ CUBA_KEYS:
   NUMBER_OF_PHYSICS_STATES:
     definition: Number of solution states to be saved
     type: integer
+
+  COHESIVE_GROUP:
+    definition: Group to define particles that can bond together
+    type: integer


### PR DESCRIPTION
This PR adds the COHESIVE_GROUP. This is needed in the OpenFoam / DEM coupling example to identify which particles belong to a given fibber.  